### PR TITLE
Fix problems with private method

### DIFF
--- a/lib/animatedgifme.rb
+++ b/lib/animatedgifme.rb
@@ -6,20 +6,14 @@ module Animatedgifme
   base_uri "animatedgif.me"
 
   def self.find(id)
-    retrieve_url get("/gifs/#{id}.json")
+    get("/gifs/#{id}.json").parsed_response["url"]
   end
 
   def self.tagged(tag)
-    retrieve_url get("/#{tag}.json")
+    get("/#{tag}.json").parsed_response["url"]
   end
 
   def self.random(tag)
     tagged(tag)
   end
-
-  private
-
-    def retrieve_url(response)
-      response.parsed_response["url"]
-    end
 end

--- a/lib/animatedgifme/version.rb
+++ b/lib/animatedgifme/version.rb
@@ -1,3 +1,3 @@
 module Animatedgifme
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
This fixes the problem with the private method `retrieve_url`.

It looks like the retrieve_url method took an argument of response but was not getting the response passed through the different methods.  So I took a more direct approach to fix the breaking behavior.  Have tested all 3 scenarios with `find` `tagged` `random` and they all return proper image urls in a stringtype.
